### PR TITLE
Transpose

### DIFF
--- a/ilupp/__init__.py
+++ b/ilupp/__init__.py
@@ -112,7 +112,7 @@ class _BaseWrapper(scipy.sparse.linalg.LinearOperator):
         self.pr.apply(x.ravel())
 
     def apply_t(self, x):
-        """Apply the preconditioner to the vector `x` in-place."""
+        """Apply the transposed preconditioner to the vector `x` in-place."""
         self.pr.apply_t(x.ravel())
 
     @property

--- a/ilupp/__init__.py
+++ b/ilupp/__init__.py
@@ -98,17 +98,22 @@ class _BaseWrapper(scipy.sparse.linalg.LinearOperator):
     :func:`apply` method.
     """
     def _matvec(self, x):
-        if x.ndim != 1:
-            raise ValueError('only implemented for 1D vectors')
-        y = x.copy()
+        y = x.copy().ravel()
         self.pr.apply(y)
+        return y
+
+    def _rmatvec(self, x):
+        y = x.copy().ravel()
+        self.pr.apply_t(y)
         return y
 
     def apply(self, x):
         """Apply the preconditioner to the vector `x` in-place."""
-        if x.ndim != 1:
-            raise ValueError('only implemented for 1D vectors')
-        self.pr.apply(x)
+        self.pr.apply(x.ravel())
+
+    def apply_t(self, x):
+        """Apply the preconditioner to the vector `x` in-place."""
+        self.pr.apply_t(x.ravel())
 
     @property
     def total_nnz(self):

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -243,6 +243,15 @@ py::class_<P> wrapPreconditioner(py::module& m, const char* classname)
                 pr.apply_preconditioner_only(ID, *y);
             }
         )
+        .def("apply_t",
+            [](const P& pr, py::buffer x)
+            {
+                auto y = make_vector(x);
+                if (y->dim() != pr.pre_image_dimension())
+                    throw std::runtime_error("vector has wrong size for preconditioner!");
+                pr.apply_preconditioner_only(TRANSPOSE, *y);
+            }
+        )
         .def_property_readonly("total_nnz", [](const P& pr) { return pr.total_nnz(); })
         .def("factors_info", [](const P& pr) { return wrap_all_factor_matrices(pr); })
         .def_property_readonly("memory_used_calculations", &P::memory_used_calculations)


### PR DESCRIPTION
Hi,

I have a problem where I needed to apply the transpose of the preconditioner. This seems to be implemented in the C++ api but not the Python bindings so I added the necessary bindings and implemented the rmatvec method for the linear operator. 

Also note that the scipy api explicitly requires support for both 1D and 2D vectors. As there is already a length check in the bindings and the scipy LinearOperator class wraps the methods to ensure the correct shapes, simply flattening the vectors before passing to the C++ code should be safe. 