### PR TITLE
Support Int64 indices in sparse matrix

### DIFF
--- a/ilupp/__init__.py
+++ b/ilupp/__init__.py
@@ -39,7 +39,7 @@ def _matrix_fields(A):
         raise ValueError("A must be a square matrix!")
 
     A.sort_indices()    # most ILU algorithms require the indices to be ascending
-    return A.data, A.indices, A.indptr, is_csr
+    return A.data, A.indices.astype(np.int64, copy=False), A.indptr.astype(np.int64, copy=False), is_csr
 
 def _matrix_from_info(data, indices, indptr, is_csr, rows, cols):
     if is_csr:

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -199,7 +199,7 @@ py::tuple wrap_permutations(const indirect_split_pseudo_triangular_preconditione
 
 std::tuple<py::array_t<Real>, Integer, Real, Real>
 solve(py::buffer A_data, py::buffer A_indices, py::buffer A_indptr, bool is_csr,
-        py::buffer rhs, double rtol, double atol, int max_iter, iluplusplus_precond_parameter param)
+        py::buffer rhs, double rtol, double atol, Integer max_iter, iluplusplus_precond_parameter param)
 {
     auto A = make_matrix(A_data, A_indices, A_indptr, is_csr);
     auto b = make_vector(rhs);

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -59,7 +59,7 @@ void check_is_1D_contiguous_int_array(const py::buffer_info& I, std::string name
     // more complicated check
     // see: https://github.com/scipy/scipy/issues/11641
     if (!(I.format.length() == 1 &&
-                (I.format[0] == 'i' || I.format[0] == 'l') &&
+                (I.format[0] == 'i' || I.format[0] == 'l' || I.format[0] == 'q') &&
                 (I.itemsize == sizeof(T))))
         throw std::runtime_error("Expected integer type with length " + std::to_string(sizeof(T))
                 + " for " + name + ", got " + I.format + "!");

--- a/src/ilupp/IChol.hpp
+++ b/src/ilupp/IChol.hpp
@@ -83,7 +83,7 @@ matrix_sparse<T> ICholT_tri(const matrix_sparse<T>& A, Integer add_fill_in, Real
 
     // estimate maximal size needed for L
     Integer reserved_memory = std::min(
-            A.actual_non_zeroes() + std::max(add_fill_in, 0) * m,   // can add at most add_fill_in entries per column
+            A.actual_non_zeroes() + std::max(add_fill_in, Integer(0)) * m,   // can add at most add_fill_in entries per column
             (Integer)(A.actual_non_zeroes() * mem_factor));         // safety in case fillin is large but threshold is large too
 
     // firstL[j]: index of the first element in the j-th column having a row index >= j

--- a/src/ilupp/declarations.h
+++ b/src/ilupp/declarations.h
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <fstream>
 #include <cstdlib>
+#include <cstdint>
 #include <ctime>
 #include <iomanip>
 #include <cmath>
@@ -45,7 +46,7 @@ namespace iluplusplus {
 //**************************************************************************************//
 
 typedef double Real;                                     // will be used for those quantities that are always Real (e.g. norms)
-typedef int Integer;                                     // for integers, particularly indices
+typedef std::int64_t Integer;                                     // for integers, particularly indices
 typedef std::complex<Real> Complex;                      // declarations for complex numbers. Will only be used if set below for the Coeff_Field.
 #ifndef ILUPLUSPLUS_USES_COMPLEX
     typedef Real Coeff_Field;                            // will be used for the coefficients of vectors and matrices

--- a/src/ilupp/sparse_implementation.h
+++ b/src/ilupp/sparse_implementation.h
@@ -4970,7 +4970,7 @@ template<class T> void matrix_sparse<T>::diagonally_dominant_symmetric_move_to_c
     Integer i,j,current_index,counter=0;
     bool acceptable_index;
     sorted_vector w;
-    vector_dense<Integer> unused(n,0); // indicates which indices have been used 0 = unused; 1= used, -1 = rejected
+    vector_dense<Integer> unused(n,Integer(0)); // indicates which indices have been used 0 = unused; 1= used, -1 = rejected
     vector_dense<Real> row_gap(n,2.0);
     vector_dense<Real> col_gap(n,2.0);
     w.resize(n); // sets all weights to 0


### PR DESCRIPTION
Hi,

scipy sparse matrices have an interesting feature in that the index type switches from `int32` to `int64` if the matrix is sufficiently large. This causes all sorts of issues and in particular scipy's build-in `spilu` function fails with an integer overflow issue with matrices of that size which is why I looked at this library in the first place. 

I managed to get `int64` indices working, however at the expense of having to copy the `indices` and `indptr` arrays in the much more common case where the indices are `int32`. Realistically, only `IChol0Preconditioner` and `ILU0Preconditioner` seem to be able to handle matrices that are large enough to trigger this issue so I am far from convinced this is a reasonable trade-off in general. Maybe it is possible to make this an installation time switch?

The first commit in this pull request just adds some explicit `Integer` casts to make sure the code still compiles after changing the definition of the `Integer` type and is probably worth including even if you do not think that supporting `int64` indices is worth the cost.